### PR TITLE
Use pointers to speed up png to rawimg conversion

### DIFF
--- a/src/Rejuvena.Collate.ModCompile/Converters/PngRawimgConverter.cs
+++ b/src/Rejuvena.Collate.ModCompile/Converters/PngRawimgConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Runtime.InteropServices;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
@@ -7,30 +8,57 @@ namespace Rejuvena.Collate.ModCompile.Converters
     public sealed class PngRawimgConverter : ContentConverter
     {
         public const int RAWIMG_FORMAT_VERSION = 1;
-        
+
+        private static Configuration config;
+        static PngRawimgConverter() {
+            config = Configuration.Default.Clone();
+            config.PreferContiguousImageBuffers = true;
+        }
+
         public override bool CanConvert(string resName) {
             return resName != "icon.png" && Path.GetExtension(resName).ToLowerInvariant() == ".png";
         }
 
-        public override void Convert(ref string resName, Stream from, MemoryStream to) {
+        public override unsafe void Convert(ref string resName, Stream from, MemoryStream to) {
             resName = Path.ChangeExtension(resName, ".rawimg");
-            
-            using Image<Rgba32> image = Image.Load<Rgba32>(from);
-            using BinaryWriter writer = new(to);
+
+            using Image<Rgba32> image = Image.Load<Rgba32>(config, from);
+            using BinaryWriter writer = new(to, System.Text.Encoding.UTF8, true);
 
             writer.Write(RAWIMG_FORMAT_VERSION);
             writer.Write(image.Width);
             writer.Write(image.Height);
+            int totalPixels = image.Width * image.Height;
 
-            for (int y = 0; y < image.Height; y++) {
-                for (int x = 0; x < image.Width; x++) {
-                    Rgba32 color = image[x, y];
-                    
-                    if (color.A == 0) color = new Rgba32(0, 0, 0, 0);
-                    to.WriteByte(color.R);
-                    to.WriteByte(color.G);
-                    to.WriteByte(color.B);
-                    to.WriteByte(color.A);
+            if (to.Length < totalPixels)
+                to.SetLength(totalPixels);
+
+            if (to.TryGetBuffer(out var buffer) && buffer.Count >= totalPixels && image.DangerousTryGetSinglePixelMemory(out var memory)) {
+                byte[] b = buffer.Array;
+                fixed (byte* _ptr = b)
+                fixed (Rgba32* _colorPtr = memory.Span)
+                {
+                    int* ptr = (int*)(_ptr + buffer.Offset);
+                    int* colorPtr = (int*)_colorPtr;
+                    for (nint i = 0, c = totalPixels / 4; i < c; i++) {
+                        int col = (ptr[i] = colorPtr[i]);
+                        if ((col & 0xFF) == 0) {
+                            ptr[i] = 0;
+                        }
+                    }
+                }
+            }
+            else {
+                for (int y = 0; y < image.Height; y++) {
+                    for (int x = 0; x < image.Width; x++) {
+                        Rgba32 color = image[x, y];
+
+                        if (color.A == 0) color = new Rgba32(0, 0, 0, 0);
+                        to.WriteByte(color.R);
+                        to.WriteByte(color.G);
+                        to.WriteByte(color.B);
+                        to.WriteByte(color.A);
+                    }
                 }
             }
 

--- a/src/Rejuvena.Collate.ModCompile/Rejuvena.Collate.ModCompile.csproj
+++ b/src/Rejuvena.Collate.ModCompile/Rejuvena.Collate.ModCompile.csproj
@@ -5,6 +5,7 @@
         <RootNamespace>Rejuvena.Collate.ModCompile</RootNamespace>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
+        <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 
         <Version>1.0.0</Version>
         <AssemblyVersion>1.0.0</AssemblyVersion>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/56768047/221391922-d4691f44-38ad-4723-a0ba-327103d61d83.png)
benchmark code:
```cs
using System;
using System.IO;
using System.Linq;
using BenchmarkDotNet;
using BenchmarkDotNet.Analysers;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Diagnosers;
using BenchmarkDotNet.Running;
using SixLabors.ImageSharp;
using SixLabors.ImageSharp.PixelFormats;

BenchmarkRunner.Run<PointerConversionTest>();

[MemoryDiagnoser]
public class PointerConversionTest 
{
    List<Image<Rgba32>> images;
    public PointerConversionTest()
    {
        var config= Configuration.Default.Clone();
        config.PreferContiguousImageBuffers = true;
        images = Directory.EnumerateFiles("images").Select(file => Image.Load<Rgba32>(config, file)).AsParallel().AsUnordered().ToList();
    }
    [Benchmark]
    public void TestNormal()
    {
        foreach(var img in images)
        {
            Convert1(img, new MemoryStream());
        }
    }
    [Benchmark]
    public void TestPointer()
    {
        foreach(var img in images)
        {
            Convert2(img, new MemoryStream());
        }
    }
    void Convert1(Image<Rgba32> image, MemoryStream to)
    {
        for (int y = 0; y < image.Height; y++)
        {
            for (int x = 0; x < image.Width; x++)
            {
                Rgba32 color = image[x, y];

                if (color.A == 0) color = new Rgba32(0, 0, 0, 0);
                to.WriteByte(color.R);
                to.WriteByte(color.G);
                to.WriteByte(color.B);
                to.WriteByte(color.A);
            }
        }
    }
    unsafe void Convert2(Image<Rgba32> image, MemoryStream to)
    {
        int totalPixels = image.Width * image.Height;
        if (to.Length < totalPixels)
            to.SetLength(totalPixels);
        if (!to.TryGetBuffer(out var buffer) || !image.DangerousTryGetSinglePixelMemory(out var memory))
            throw new Exception("Failure to get buffer or pixel memory");
        byte[] b = buffer.Array!;
        fixed (byte* _ptr = b)
        fixed (Rgba32* _colorPtr = memory.Span)
        {
            int* ptr = (int*)(_ptr + buffer.Offset);
            int* colorPtr = (int*)_colorPtr;
            for (nint i = 0, c = totalPixels / 4; i < c; i++)
            {
                int col = (ptr[i] = colorPtr[i]);
                if ((col & 0xFF) == 0)
                {
                    ptr[i] = 0;
                }
            }
        }
    }
}